### PR TITLE
Translate coolant and tool change codes for WinCNC

### DIFF
--- a/onshape-to-wincnc.pyw
+++ b/onshape-to-wincnc.pyw
@@ -28,6 +28,30 @@ import os
 import re
 import tkinter as tk
 from tkinter import filedialog, messagebox
+from typing import Optional
+
+
+def _env_int(name: str, default: Optional[int]) -> Optional[int]:
+    """Helper to safely parse integer environment overrides."""
+
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw, 10)
+    except ValueError:
+        return default
+    return value if value > 0 else None
+
+
+SHOP_SABRE_TOOL_CHANGE_COMMAND = (
+    os.environ.get('SHOP_SABRE_TOOL_CHANGE_CMD', 'TC').strip().upper() or 'TC'
+)
+SHOP_SABRE_MIST_OUTPUT = _env_int('SHOP_SABRE_MIST_OUTPUT', 1)
+SHOP_SABRE_FLOOD_OUTPUT = _env_int('SHOP_SABRE_FLOOD_OUTPUT', 2)
 
 def remove_parentheses_comments(line: str) -> str:
     """Strip any text enclosed in parentheses from the line."""
@@ -86,6 +110,81 @@ def process_arc_line(line: str, last_g: str):
             # so we can simply prefix without worrying about them.
             return f"{last_g} {line.lstrip()}", last_g
     return line, last_g
+
+
+def translate_tool_change_command(tool_number: Optional[str]) -> str:
+    """Map M6 requests to the ShopSabre-specific TC command."""
+
+    base = SHOP_SABRE_TOOL_CHANGE_COMMAND
+    if tool_number:
+        return f"{base},{tool_number}"
+    return f"{base} [Tool change requested without explicit T-word]"
+
+
+def translate_coolant_code(code: str) -> list[str]:
+    """Map generic coolant M-codes to WinCNC SO outputs."""
+
+    upper = code.upper()
+    lines: list[str] = []
+
+    def _append(channel: Optional[int], state: int) -> None:
+        if channel is None:
+            return
+        lines.append(f"SO,{channel},{state}")
+
+    if upper == 'M7':
+        _append(SHOP_SABRE_MIST_OUTPUT, 1)
+    elif upper == 'M8':
+        _append(SHOP_SABRE_FLOOD_OUTPUT, 1)
+    elif upper == 'M9':
+        _append(SHOP_SABRE_MIST_OUTPUT, 0)
+        _append(SHOP_SABRE_FLOOD_OUTPUT, 0)
+    return lines
+
+
+def preprocess_tokens_for_machine_specific(
+    tokens: list[str],
+    last_tool: Optional[str],
+    remove_coolant: bool,
+    remove_toolchange: bool,
+):
+    """Extract ShopSabre-specific commands before generic token filtering."""
+
+    tool_in_line = None
+    for tok in tokens:
+        up = tok.upper()
+        if up.startswith('T') and up[1:].replace('.', '').isdigit():
+            tool_in_line = tok[1:]
+    if tool_in_line:
+        last_tool = tool_in_line
+
+    pre_lines: list[str] = []
+    post_lines: list[str] = []
+    remaining: list[str] = []
+    seen_general = False
+
+    def _target_lines() -> list[str]:
+        return post_lines if seen_general else pre_lines
+
+    for tok in tokens:
+        up = tok.upper()
+        if up.startswith('T') and up[1:].replace('.', '').isdigit():
+            continue
+        if up == 'M6' and not remove_toolchange:
+            line = translate_tool_change_command(last_tool)
+            _target_lines().append(line)
+            continue
+        if up in ('M7', 'M8', 'M9') and not remove_coolant:
+            translated = translate_coolant_code(up)
+            _target_lines().extend(translated)
+            continue
+        if tok:
+            # Treat any remaining token as a general token; whitespace has been stripped upstream.
+            if up:
+                seen_general = True
+            remaining.append(tok)
+
+    return remaining, pre_lines, post_lines, last_tool
 
 
 def remove_unsupported_tokens(tokens, remove_coolant: bool, remove_toolchange: bool):
@@ -173,6 +272,7 @@ def convert_lines(lines, remove_coolant: bool = True, remove_toolchange: bool = 
     """
     converted = []
     last_motion = None
+    last_tool = None
     for original_line in lines:
         line = original_line.rstrip('\n')
         line = remove_semicolon_comments(line)
@@ -182,8 +282,18 @@ def convert_lines(lines, remove_coolant: bool = True, remove_toolchange: bool = 
             continue
         for sm_line in split_spindle_speed_and_m(line.strip()):
             tokens = sm_line.split()
+            tokens, pre_lines, post_lines, last_tool = preprocess_tokens_for_machine_specific(
+                tokens,
+                last_tool,
+                remove_coolant,
+                remove_toolchange,
+            )
+            for pre in pre_lines:
+                converted.append(pre)
             tokens = remove_unsupported_tokens(tokens, remove_coolant, remove_toolchange)
             if not tokens:
+                if post_lines:
+                    converted.extend(post_lines)
                 continue
             grouped = split_by_multiple_commands(tokens)
             for group in grouped:
@@ -208,6 +318,8 @@ def convert_lines(lines, remove_coolant: bool = True, remove_toolchange: bool = 
                         elif last_motion in ('G0', 'G1') and has_lin:
                             group.insert(0, last_motion)
                 converted.append(' '.join(group))
+            if post_lines:
+                converted.extend(post_lines)
     # After processing all lines, perform post-processing on the converted list.
     # 1. Handle placement of G49 (tool length cancel) commands:
     #    - If there is a spindle stop (M5), remove any G49 before the first M5


### PR DESCRIPTION
## Summary
- translate retained M7/M8/M9 commands into the SO,<channel>,<state> output toggles that ShopSabre WinCNC expects and convert retained M6 calls into TC,<tool> commands
- capture the most recent T-word, preserve command ordering around motion lines, and allow overriding coolant outputs or the tool-change macro via environment variables
- document the new behavior and overrides in the README so operators know how to keep coolant and ATC instructions in their converted files

## Testing
- `python - <<'PY'
import importlib.machinery, types
loader = importlib.machinery.SourceFileLoader('converter', 'onshape-to-wincnc.pyw')
module = types.ModuleType(loader.name)
loader.exec_module(module)
lines = [
    'T2 M6\n',
    'M8\n',
    'G1 X1.0 Y2.0 F100\n',
    'M9\n',
]
print('\n'.join(module.convert_lines(lines, remove_coolant=False, remove_toolchange=False)))
PY`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc9f1175c8327bbcb5987749603b5)