### PR TITLE
Clarify README for WinCNC converter behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 ---
 A simple python script to convert Onshape CAM Studio .nc files to be compatible with ShopSabre WinCNC.
 
-Brought to you by FRC 7028 Binary Battlion.
+Brought to you by FRC 7028 Binary Battalion.
 
-Python is required to run the program- you can install it via the microsoft store.
+Python is required to run the program—you can install it via the Microsoft Store.
 
 WARNING: Use at your own risk. Always simulate before executing toolpaths.
 
 ---
 
 # What does the script do?
-This script takes G-code exported from Onshape CAM Studio and rewrites it into a format that ShopSabre’s WinCNC controller can safely and reliably run. WinCNC is far more strict than generic Fanuc-style posts, so the script cleans and restructures the file: it removes unsupported tokens (program numbers, comments, redundant modal codes), splits combined commands (like S and M3), forces WinCNC-safe arc formatting, normalizes motion commands, and ensures the correct placement of things like tool-length cancel (G49). It also includes optional removal of mist and tool-change commands via GUI checkboxes. When you leave those options unchecked the converter rewrites `M7/M9` into WinCNC mister commands (`M11C<port>` on / `M12C<port>` off) and maps `M6` to the ShopSabre `TC,<tool>` automatic tool change command so that coolant and tool swaps actually run on the router instead of being dropped or ignored. Before converting, the script analyzes Z-values after spindle start to detect if Onshape’s Setup → Position Type was incorrectly set—blocking conversion with a red error dialog if the toolpath would cut entirely above the stock. The result is a clean .tap file prefixed with SS_ by default (you can change the naming pattern in **Customize → Output Settings…**), ready to run on a ShopSabre without syntax errors, unexpected behavior, or manual editing.
+This script takes G-code exported from Onshape CAM Studio and rewrites it into a format that ShopSabre’s WinCNC controller can safely and reliably run. WinCNC is far more strict than generic Fanuc-style posts, so the script cleans and restructures the file: it removes unsupported tokens (program numbers, comments, redundant modal codes), splits combined commands (like S and M3), forces WinCNC-safe arc formatting, normalizes motion commands, and ensures the correct placement of things like tool-length cancel (G49). It also includes optional removal of mist and tool-change commands via GUI checkboxes. When you leave those options unchecked the converter rewrites `M7/M9` into WinCNC mister commands (`M11C<port>` on / `M12C<port>` off) and keeps `T`/`M6` pairs together in the `TX M6` format WinCNC expects so automated tool changes remain intact. Before converting, the script analyzes Z-values after spindle start to detect if Onshape’s Setup → Position Type or zero plane is wrong—warning for top-of-stock setups that never cut below Z0 and for bottom-of-part setups that dip below Z0. The result is a clean .tap file prefixed with `SS23_` by default (you can change the naming pattern in **Customize → Output Settings…**), ready to run on a ShopSabre without syntax errors, unexpected behavior, or manual editing.
 
-### ShopSabre mister & tool-change mapping
+### ShopSabre mister handling
 
-Configure the mister port that should be toggled by mist commands in **Customize → Machine Settings…**. When mist is enabled for conversion, `M7` becomes `M11C<port>` (on) and `M9` becomes `M12C<port>` (off) using the port you specify. Automatic tool changes are issued with the WinCNC `TC,<tool>` command using the most recent `T` word that appeared in the Onshape program.
+Configure the mister port that should be toggled by mist commands in **Customize → Machine Settings…**. When mist is enabled for conversion, `M7` becomes `M11C<port>` (on) and `M9` becomes `M12C<port>` (off) using the port you specify.
 
-If your machine uses a different macro for the tool changer you can update it directly inside the app. The mister port and tool change command are stored in your user profile so they persist between runs. Any environment variables you set are still honored the first time you launch the tool (before you save your own values).
+The mister port setting is stored in your user profile so it persists between runs. Any environment variable you set is still honored the first time you launch the tool (before you save your own values).
 
-Need to control where the converted file is written or how it is named? Choose **Customize → Output Settings…** to select a default destination folder (or stick with “same folder as input”), pick whether the custom text should act as a prefix or suffix, and enter the text you want to apply. The converter then uses those preferences every time it proposes an output path after you pick an input file.
+Need to control where the converted file is written or how it is named? Choose **Customize → Output Settings…** to select a default destination folder (or stick with “same folder as input”), pick whether the custom text should act as a prefix or suffix, and enter the text you want to apply. The converter defaults to prefixing files with `SS23_` and uses your preferences every time it proposes an output path after you pick an input file.
 
 Leave the checkboxes unchecked when you want these WinCNC-specific commands emitted; check them to strip the codes entirely.
 
@@ -27,9 +27,9 @@ Leave the checkboxes unchecked when you want these WinCNC-specific commands emit
 
 # Preparation
 
-The part you are machining must be in the correct orientation in the part studio it was created in. If you alreayd made the part in the wrong orientation, you can proxy it by creating a new part studio thgat references the original, then transofmr it.
+The part you are machining must be in the correct orientation in the part studio it was created in. If you already made the part in the wrong orientation, you can proxy it by creating a new part studio that references the original, then transform it.
 
-Create a new version of your document to create a snapshot of the part. This is required for Onshape CAM. A CAM Studio will not update automatically when the part is edited in the Part Studio it was created in- it only uses the versioned one. If you need to apply changes to the versioned part in the CAM Studio, you must first create a new version of the document, then update it in the CAM Studio.
+Create a new version of your document to create a snapshot of the part. This is required for Onshape CAM. A CAM Studio will not update automatically when the part is edited in the Part Studio it was created in—it only uses the versioned one. If you need to apply changes to the versioned part in the CAM Studio, you must first create a new version of the document, then update it in the CAM Studio.
 
 ---
 
@@ -79,12 +79,12 @@ On the bottom bar click the `+` button to create a new tab and select `Create CA
     
     - Reference [speeds/feeds table](https://www.notion.so/CNC-Router-Tooling-2a842da8b6c580ff91c6d65a669c7352?pvs=21)
     
-    Chose the `Link` tab at the top and select `Global Lead In`
+    Choose the `Link` tab at the top and select `Global Lead In`
     
     - Type = Vertical profile ramp
     - Axis orientation = Tangential
     - Maximum angle change = 3
-    - Length =6”
+    - Length = 6”
     - Height = same as layer height (0.05”)
     - Feed rate = 60%
     </aside>


### PR DESCRIPTION
## Summary
- correct README feature descriptions for mister handling, tool-change formatting, and zero-plane warnings
- document default `SS23_` output naming and persistent mister settings
- fix typos and clarity issues in preparation and toolpath setup guidance

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e30ce1c848327b774dd7f20ed71d3)