### PR TITLE
Inline mister port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This script takes G-code exported from Onshape CAM Studio and rewrites it into a
 
 ### ShopSabre mister handling
 
-Configure the mister port that should be toggled by mist commands in **Customize → Machine Settings…**. When mist is enabled for conversion, `M7` becomes `M11C<port>` (on) and `M9` becomes `M12C<port>` (off) using the port you specify.
+Configure the mister port that should be toggled by mist commands in the **Conversion options** section of the main window. When mist is enabled for conversion, `M7` becomes `M11C<port>` (on) and `M9` becomes `M12C<port>` (off) using the port you specify.
 
 The mister port setting is stored in your user profile so it persists between runs. Any environment variable you set is still honored the first time you launch the tool (before you save your own values).
 


### PR DESCRIPTION
## Summary
- move mister port entry into the main Conversion options card
- update conversion flow to validate and save the mister port from the main window
- refresh documentation to point to the inline mister configuration

## Testing
- python -m py_compile onshape-to-wincnc.pyw

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e35c80d408327b5897adbe18893b0)