### PR TITLE
Apply modern primary and accent theme

### DIFF
--- a/onshape-to-wincnc.pyw
+++ b/onshape-to-wincnc.pyw
@@ -668,7 +668,17 @@ class ConverterGUI:
     def __init__(self, root: tk.Tk) -> None:
         self.root = root
         self.root.title('Onshape to WinCNC Converter')
-        self.root.configure(bg='#f4f6fb')
+        self.palette = {
+            'primary': '#001489',
+            'accent': '#ffd400',
+            'accent_active': '#e6be00',
+            'background': '#f5f7fb',
+            'card': '#ffffff',
+            'border': '#d5d7de',
+            'text': '#111111',
+            'muted_text': '#4b5563',
+        }
+        self.root.configure(bg=self.palette['background'])
         self.settings = SETTINGS
         self.output_settings_window: Optional[tk.Toplevel] = None
 
@@ -678,15 +688,53 @@ class ConverterGUI:
         except tk.TclError:
             # Fallback to default theme if clam is unavailable.
             pass
-        style.configure('TFrame', background='#f4f6fb')
-        style.configure('Card.TFrame', background='#ffffff', borderwidth=1, relief='solid')
-        style.configure('Card.TLabel', background='#ffffff', font=('Segoe UI', 10))
-        style.configure('Heading.TLabel', background='#ffffff', font=('Segoe UI Semibold', 11))
-        style.configure('Body.TLabel', background='#f4f6fb', font=('Segoe UI', 10))
-        style.configure('Status.TLabel', background='#f4f6fb', foreground='#2563eb', font=('Segoe UI', 10))
-        style.configure('Accent.TButton', font=('Segoe UI Semibold', 11), padding=(12, 6), foreground='#ffffff',
-                        background='#2563eb')
-        style.map('Accent.TButton', background=[('active', '#1d4ed8')], foreground=[('disabled', '#d1d5db')])
+        style.configure('TFrame', background=self.palette['background'])
+        style.configure(
+            'Card.TFrame',
+            background=self.palette['card'],
+            borderwidth=1,
+            relief='solid',
+            bordercolor=self.palette['border'],
+        )
+        style.configure(
+            'Card.TLabel',
+            background=self.palette['card'],
+            foreground=self.palette['text'],
+            font=('Segoe UI', 10),
+        )
+        style.configure(
+            'Heading.TLabel',
+            background=self.palette['card'],
+            foreground=self.palette['primary'],
+            font=('Segoe UI Semibold', 11),
+        )
+        style.configure(
+            'Body.TLabel',
+            background=self.palette['background'],
+            foreground=self.palette['text'],
+            font=('Segoe UI', 10),
+        )
+        style.configure(
+            'Status.TLabel',
+            background=self.palette['background'],
+            foreground=self.palette['primary'],
+            font=('Segoe UI', 10),
+        )
+        style.configure(
+            'Accent.TButton',
+            font=('Segoe UI Semibold', 11),
+            padding=(12, 6),
+            foreground='#000000',
+            background=self.palette['accent'],
+            bordercolor=self.palette['accent'],
+            focusthickness=1,
+        )
+        style.map(
+            'Accent.TButton',
+            background=[('active', self.palette['accent_active'])],
+            foreground=[('disabled', '#6b7280')],
+            bordercolor=[('active', self.palette['accent_active'])],
+        )
 
         self.main_frame = ttk.Frame(root, padding=20)
         self.main_frame.grid(row=0, column=0, sticky='nsew')
@@ -844,7 +892,7 @@ class ConverterGUI:
 
         win = tk.Toplevel(self.root)
         win.title('Customize Output Settings')
-        win.configure(bg='#f4f6fb')
+        win.configure(bg=self.palette['background'])
         win.resizable(False, False)
         win.transient(self.root)
         self.output_settings_window = win
@@ -997,14 +1045,14 @@ class ConverterGUI:
 
         # Status bar at top-right
         status_var = tk.StringVar(value="Ready")
-        status_label = ttk.Label(header_frame, textvariable=status_var, foreground='#2563eb')
+        status_label = ttk.Label(header_frame, textvariable=status_var, foreground=self.palette['primary'])
         status_label.pack(side='right')
 
         # Instructions
         ttk.Label(
             main,
             text="Changes take effect immediately after clicking 'Save & Reload Rules'",
-            foreground='#555555',
+            foreground=self.palette['muted_text'],
             font=('Segoe UI', 9, 'italic')
         ).pack(anchor='w', pady=(0, 10))
 


### PR DESCRIPTION
## Summary
- introduce a centralized color palette using the new primary and accent hues
- refresh ttk frame, label, and button styles to match the updated theme
- propagate the theme to dialogs and status elements for consistent appearance

## Testing
- python -m py_compile onshape-to-wincnc.pyw

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920946289d48327942286510a37cb84)