### PR TITLE
Add muted palette color for link button style

### DIFF
--- a/onshape-to-wincnc.pyw
+++ b/onshape-to-wincnc.pyw
@@ -675,6 +675,7 @@ class ConverterGUI:
             'background': '#001489',
             'card': '#ffffff',
             'border': '#ffd400',
+            'muted': '#cbd5e1',
             'text': '#0f172a',
             'muted_text': '#4b5563',
             'on_primary_text': '#ffffff',


### PR DESCRIPTION
## Summary
- add the missing `muted` color to the GUI palette so styles initialize without KeyError

## Testing
- python -m py_compile onshape-to-wincnc.pyw

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920bcd53568832794b60ef7a3ea3d6c)